### PR TITLE
Use portable shebangs

### DIFF
--- a/h2mm
+++ b/h2mm
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 VERSION="0.3.2"
 

--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 RED='\033[0;31m'


### PR DESCRIPTION
This allows the scripts to run on systems that do not use the Filesystem Hierarchy Standard (like NixOS) without breaking it for those which do.