### PR TITLE
Enhance compatibility with alternative coreutils implementations

### DIFF
--- a/h2mm
+++ b/h2mm
@@ -377,7 +377,7 @@ EOF
 function check_for_updates() {
 	if [[ -f "$LAST_CHECKED_UPDATE_FILE" ]]; then
 		last_update=$(cat "$LAST_CHECKED_UPDATE_FILE")
-		if [[ "$(date +%s)" -lt "$(date +%s -d "$last_update + 1 hour")" ]]; then
+		if [[ "$(date +%s)" -lt $(("$(date +%s -d "$last_update")" + 3600)) ]]; then
 			return
 		fi
 	else


### PR DESCRIPTION
Have been using h2mm-cli for some time now with great success. However, while testing out the script with the [uutils coreutils](https://github.com/uutils/coreutils), inspired by Ubuntu's [oxidizr](https://github.com/jnsgruk/oxidizr) [experiment](https://www.phoronix.com/news/Ubuntu-25.10-Rust-Coreutils), I discovered that the `check_for_updates()` function errors out due to limitations with the current parsing implementation. This PR implements a workaround, adding 3600 seconds *after* the Unix timestamp is computed by `date`, rather than adding 1 hour within the date command. This change should also fix the aforementioned error with other coreutils implementations, such as [`toybox`](https://github.com/landley/toybox) (however seemingly not [`busybox`](https://www.busybox.net/) due to it not parsing formatted dates).